### PR TITLE
Edited plugin folders and activated plugin

### DIFF
--- a/install/package.json
+++ b/install/package.json
@@ -28,6 +28,8 @@
         ]
     },
     "dependencies": {
+        "nodebb-plugin-role-groups": "file:./plugins/nodebb-plugin-role-groups",
+        "nodebb-plugin-composer-default": "10.2.51",
         "@adactive/bootstrap-tagsinput": "0.8.2",
         "@fontsource/inter": "5.2.5",
         "@fontsource/poppins": "5.2.6",
@@ -97,7 +99,6 @@
         "multiparty": "4.2.3",
         "nconf": "0.13.0",
         "nodebb-plugin-2factor": "7.5.10",
-        "nodebb-plugin-composer-default": "10.2.51",
         "nodebb-plugin-dbsearch": "6.2.19",
         "nodebb-plugin-emoji": "6.0.2",
         "nodebb-plugin-emoji-android": "4.1.1",

--- a/plugins/nodebb-plugin-composer-default/plugin.json
+++ b/plugins/nodebb-plugin-composer-default/plugin.json
@@ -1,6 +1,8 @@
 {
 	"id": "nodebb-plugin-composer-default",
 	"url": "https://github.com/NodeBB/nodebb-plugin-composer-default",
+	"name": "Default Composer",
+  "description": "The default composer plugin for NodeBB.",
 	"library": "library.js",
 	"hooks": [
 		{ "hook": "static:app.load", "method": "init" },

--- a/plugins/nodebb-plugin-composer-default/static/templates/partials/composer-formatting.tpl
+++ b/plugins/nodebb-plugin-composer-default/static/templates/partials/composer-formatting.tpl
@@ -60,8 +60,7 @@
 			component="composer/visibility"
 			aria-label="[[topic:composer.visibility]]">
 			<option value="everyone">Everyone</option>
-			<option value="all_instructors">All Instructors</option>
-			<option value="specific_instructors">Specific Instructors…</option>
+			<option value="all_instructors">All Instructors</option>./n
 		</select>
 		</li>
 		{{{ end }}}

--- a/plugins/nodebb-plugin-role-groups/library.js
+++ b/plugins/nodebb-plugin-role-groups/library.js
@@ -1,18 +1,21 @@
+
 'use strict';
 
 const groups = require.main.require('./src/groups');
 
-async function ensureGroups(names) {
-  await Promise.all(names.map(async (name) => {
-    const exists = await groups.exists(name);
-    if (!exists) {
-      await groups.create({ name, system: 0, hidden: 0 });
-      console.log(`[roles] created group: ${name}`);
-    }
-  }));
+async function ensure(name) {
+  if (!(await groups.exists(name))) {
+    await groups.create({ name, system: 0, hidden: 0, private: 0, disableJoinRequests: 1, description: '' });
+  } else {
+    if (typeof groups.setHidden === 'function') await groups.setHidden(name, 0);
+    if (typeof groups.setPrivate === 'function') await groups.setPrivate(name, 0);
+  }
 }
 
-exports.load = async function (params) {
-  // Called when NodeBB boots
-  await ensureGroups(['students', 'instructors']);
+exports.load = async function () {
+  for (const name of ['students', 'tas', 'instructors']) {
+    await ensure(name);
+  }
+  // optional log to confirm it ran
+  console.log('[role-groups] ensured students/tas/instructors');
 };

--- a/plugins/nodebb-plugin-role-groups/package.json
+++ b/plugins/nodebb-plugin-role-groups/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "nodebb-plugin-role-groups",
+  "version": "1.0.0",
+  "main": "library.js",
+  "description": "Seeds 'students' and 'instructors' groups at NodeBB startup"
+}

--- a/plugins/nodebb-plugin-role-groups/plugin.json
+++ b/plugins/nodebb-plugin-role-groups/plugin.json
@@ -1,6 +1,7 @@
 {
   "id": "nodebb-plugin-role-groups",
   "name": "Role Groups Seeder",
+  "description": "A plugin to seed role groups.",
   "library": "./library.js",
   "hooks": [
     { "hook": "static:app.load", "method": "load" }


### PR DESCRIPTION
[Addresses 18](https://github.com/CMU-313/nodebb-fall-2025-the-good-team/issues/18#issue-3435516796)


Students can now see all instructors' names. To use this feature, you navigate to Comments and Feedback section, and create a New Topic. There's a drop down with the following default options for post visibility: Everyone and Instructors. Now you will be able to see every person logged in as "instructor". You can choose between these options, changing the visibility of your post. 

This feature takes place in the Comments and Feedback Section. 

6 Files Changed:
plugins/nodebb-plugin-role-groups/plugin.json
plugins/nodebb-plugin-role-groups/package.json
plugins/nodebb-plugin-role-groups/library.js
plugins/nodebb-plugin-composer-default/static/templates/partials/composer-formatting.tpl
plugins/nodebb-plugin-composer-default/plugin.json
install/package.json