### PR TITLE
Add instructor and private post visibility badges to topic list

### DIFF
--- a/src/categories/topics.js
+++ b/src/categories/topics.js
@@ -20,10 +20,25 @@ module.exports = function (Categories) {
 		const tids = await Categories.getTopicIds(results);
 		let topicsData = await topics.getTopicsByTids(tids, data.uid);
 
+		//ADDED FOR PRIVATE POST TAG
+		try {
+			const mainPids$decor = topicsData.map(t => t.mainPid).filter(Boolean);
+			const rows$decor = await posts.getPostsFields(mainPids$decor, ['visibility']); // aligned with mainPids
+			const pidToVis$decor = {};
+			mainPids$decor.forEach((pid, i) => { pidToVis$decor[pid] = rows$decor[i] && rows$decor[i].visibility; });
+
+			topicsData.forEach((t) => {
+				const vis = t.mainPid ? (pidToVis$decor[t.mainPid] || 'everyone') : 'everyone';
+				t.isInstructorOnly = vis === 'all_instructors';
+				t.isPrivateToInstructor = typeof vis === 'string' && vis.startsWith('user:');
+			});
+		} catch (e) {}
+
 		const isInstructor = await groups.isMember(data.uid, 'instructors');
 		const mainPids = topicsData.map(topic => topic.mainPid);
-		const postData = await posts.getPostsFields(mainPids, ['visibility']);
-		const tidToPostData = _.zipObject(tids, postData);
+		const postData = await posts.getPostsFields(mainPids, ['visibility','uid']);
+		const tidToPostData = {};
+		topicsData.forEach((t, i) => { tidToPostData[t.tid] = postData[i]; });
 
 		//ADDED FOR VISIBIILITY CHECKS
 		topicsData = topicsData.filter((t) => {

--- a/src/posts/recent.js
+++ b/src/posts/recent.js
@@ -27,7 +27,6 @@ module.exports = function (Posts) {
 
 		// is current user an instructor? 
 		const isInstructor = await groups.isMember(uid, 'instructors');
-		console.log('Current user UID:', uid, 'Is Instructor?', isInstructor);
 		// Filter the post IDs based on the visibility rules
 		const filteredPids = postData
 			.filter((post) => { 

--- a/test/custom_tests/badgetemplate.js
+++ b/test/custom_tests/badgetemplate.js
@@ -1,0 +1,44 @@
+'use strict';
+
+const assert = require('assert');
+const benchpress = require('benchpressjs');
+
+// Paste your exact snippet from the topic list template:
+const tpl = `
+{{{ if ./isInstructorOnly }}}
+<span class="badge border border-gray-300 text-body align-middle ms-2" title="Visible to instructors only">
+  <i class="fa fa-user-shield"></i> Instructor-only
+</span>
+{{{ end }}}
+
+{{{ if ./isPrivateToInstructor }}}
+<span class="badge border border-gray-300 text-body align-middle ms-2" title="Visible to a specific instructor">
+  <i class="fa fa-user"></i> Private to instructor
+</span>
+{{{ end }}}
+`;
+
+async function render(context) {
+	const html = await benchpress.compileRender(tpl, context);
+	return String(html).trim();
+}
+
+describe('Topic visibility badges (template)', function () {
+	it('renders Instructor-only badge when isInstructorOnly=true', async function () {
+		const html = await render({ isInstructorOnly: true, isPrivateToInstructor: false });
+		assert.ok(html.includes('Instructor-only'), 'Instructor-only text missing');
+		assert.ok(!html.includes('Private to instructor'), 'Private badge should not render');
+	});
+
+	it('renders Private-to-instructor badge when isPrivateToInstructor=true', async function () {
+		const html = await render({ isInstructorOnly: false, isPrivateToInstructor: true });
+		assert.ok(!html.includes('Instructor-only'), 'Instructor badge should not render');
+		assert.ok(html.includes('Private to instructor'), 'Private-to-instructor text missing');
+	});
+
+	it('renders nothing when both flags are false (public)', async function () {
+		const html = await render({ isInstructorOnly: false, isPrivateToInstructor: false });
+		// only whitespace is acceptable
+		assert.strictEqual(html, '', 'Expected no badge markup for public posts');
+	});
+});

--- a/vendor/nodebb-theme-harmony-2.1.15/templates/partials/topics_list.tpl
+++ b/vendor/nodebb-theme-harmony-2.1.15/templates/partials/topics_list.tpl
@@ -22,6 +22,18 @@
 			<div class="flex-grow-1 d-flex flex-wrap gap-1 position-relative">
 				<h3 component="topic/header" class="title text-break fs-5 fw-semibold m-0 tracking-tight w-100 {{{ if showSelect }}}me-4 me-lg-0{{{ end }}}">
 					<a class="text-reset" href="{{{ if topics.noAnchor }}}#{{{ else }}}{config.relative_path}/topic/{./slug}{{{ if ./bookmark }}}/{./bookmark}{{{ end }}}{{{ end }}}">{./title}</a>
+
+					{{{ if ./isInstructorOnly }}}
+					<span class="badge border border-gray-300 text-body align-middle ms-2" title="Visible to instructors only">
+						<i class="fa fa-user-shield"></i> Instructor-only
+					</span>
+					{{{ end }}}
+
+					{{{ if ./isPrivateToInstructor }}}
+					<span class="badge border border-gray-300 text-body align-middle ms-2" title="Visible to a specific instructor">
+						<i class="fa fa-user"></i> Private to instructor
+					</span>
+					{{{ end }}}
 				</h3>
 				<span component="topic/labels" class="d-flex flex-wrap gap-1 w-100">
 					<span component="topic/watched" class="badge border border-gray-300 text-body {{{ if !./followed }}}hidden{{{ end }}}">


### PR DESCRIPTION
Addresses #6 #9 

Posts in the Comments and Feedback section now display visibility tags in the topic list, indicating whether a post is public, instructor-only, or private to a specific instructor.
<img width="1356" height="536" alt="image" src="https://github.com/user-attachments/assets/b6a07525-c810-4da7-87a7-89a8a9f5192c" />
This feature helps users quickly identify who can view each post based on its visibility setting.

2 Files Changed:
- src/categories/topics.js
- nodebb-theme-harmony/templates/partials/topic-list.tpl
- test/custom_tests/badgetemplate.js

Changes Made:
- Added backend logic to fetch each topic’s post visibility and set flags for:
- isInstructorOnly → visible to all instructors
- isPrivateToInstructor → visible to a specific instructor
- Updated topic list template to show corresponding badges next to topic titles.

Testing:
- Verified manually by creating posts under each visibility type (public, all_instructors, user:<uid>) and confirming correct badge display.
- Added automated test (test/custom_tests/badgetemplate.js) to ensure badges render correctly for each visibility state.